### PR TITLE
apply-patch-to-manage-disk-space

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>9</source>
+                    <target>9</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/leansoft/bigqueue/page/MappedPageImpl.java
+++ b/src/main/java/com/leansoft/bigqueue/page/MappedPageImpl.java
@@ -1,13 +1,14 @@
 package com.leansoft.bigqueue.page;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.misc.Unsafe;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
 
 public class MappedPageImpl implements IMappedPage, Closeable {
 	
@@ -77,8 +78,7 @@ public class MappedPageImpl implements IMappedPage, Closeable {
 		return buf;
 	}
 	
-	private static void unmap(MappedByteBuffer buffer)
-	{
+    private static void unmap(MappedByteBuffer buffer) {
 		Cleaner.clean(buffer);
 	}
 	
@@ -86,36 +86,26 @@ public class MappedPageImpl implements IMappedPage, Closeable {
      * Helper class allowing to clean direct buffers.
      */
     private static class Cleaner {
-        public static final boolean CLEAN_SUPPORTED;
-        private static final Method directBufferCleaner;
-        private static final Method directBufferCleanerClean;
+
+        private static Unsafe unsafe;
 
         static {
-            Method directBufferCleanerX = null;
-            Method directBufferCleanerCleanX = null;
-            boolean v;
             try {
-                directBufferCleanerX = Class.forName("java.nio.DirectByteBuffer").getMethod("cleaner");
-                directBufferCleanerX.setAccessible(true);
-                directBufferCleanerCleanX = Class.forName("sun.misc.Cleaner").getMethod("clean");
-                directBufferCleanerCleanX.setAccessible(true);
-                v = true;
+                Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                unsafe = (Unsafe) f.get(null);
             } catch (Exception e) {
-                v = false;
+                logger.warn("Unsafe Not support {}", e.getMessage(), e);
             }
-            CLEAN_SUPPORTED = v;
-            directBufferCleaner = directBufferCleanerX;
-            directBufferCleanerClean = directBufferCleanerCleanX;
         }
 
         public static void clean(ByteBuffer buffer) {
     		if (buffer == null) return;
-            if (CLEAN_SUPPORTED && buffer.isDirect()) {
-                try {
-                    Object cleaner = directBufferCleaner.invoke(buffer);
-                    directBufferCleanerClean.invoke(cleaner);
-                } catch (Exception e) {
-                    // silently ignore exception
+            if (buffer.isDirect()) {
+                if (unsafe != null) {
+                    unsafe.invokeCleaner(buffer);
+                } else {
+                    logger.warn("Unable to clean bytebuffer");
                 }
             }
         }


### PR DESCRIPTION
## Motivation
Today kproxy is running Java11 running on Ubuntu 18.This configuration in addition to an issue with BigQueue client can cause deleted files to still be on disk until process restart.

## Implementation
apply a custom patch 